### PR TITLE
Add configurable forecast/warning sensors and fix API errors

### DIFF
--- a/custom_components/willyweather/binary_sensor.py
+++ b/custom_components/willyweather/binary_sensor.py
@@ -18,6 +18,7 @@ from .const import (
     CONF_INCLUDE_WARNINGS,
     CONF_STATION_ID,
     CONF_STATION_NAME,
+    CONF_WARNING_MONITORED,
     DOMAIN,
     MANUFACTURER,
     WARNING_BINARY_SENSOR_TYPES,
@@ -45,15 +46,23 @@ async def async_setup_entry(
 
     # Add warning sensors if enabled
     if entry.options.get(CONF_INCLUDE_WARNINGS, False):
+        # Get list of monitored warning types
+        monitored_warnings = entry.options.get(
+            CONF_WARNING_MONITORED,
+            list(WARNING_BINARY_SENSOR_TYPES.keys())
+        )
+
         for sensor_type in WARNING_BINARY_SENSOR_TYPES:
-            entities.append(
-                WillyWeatherWarningBinarySensor(
-                    coordinator,
-                    station_id,
-                    station_name,
-                    sensor_type,
+            # Only add if this warning type is in the monitored list
+            if sensor_type in monitored_warnings:
+                entities.append(
+                    WillyWeatherWarningBinarySensor(
+                        coordinator,
+                        station_id,
+                        station_name,
+                        sensor_type,
+                    )
                 )
-            )
 
     async_add_entities(entities)
 

--- a/custom_components/willyweather/const.py
+++ b/custom_components/willyweather/const.py
@@ -32,6 +32,9 @@ CONF_INCLUDE_FORECAST_SENSORS: Final = "include_forecast_sensors"
 CONF_FORECAST_DAYS: Final = "forecast_days"
 CONF_FORECAST_MONITORED: Final = "forecast_monitored"
 
+# Warning sensor configuration
+CONF_WARNING_MONITORED: Final = "warning_monitored"
+
 # Additional forecast options (checkboxes)
 CONF_INCLUDE_UV: Final = "include_uv"
 CONF_INCLUDE_TIDES: Final = "include_tides"

--- a/custom_components/willyweather/coordinator.py
+++ b/custom_components/willyweather/coordinator.py
@@ -150,7 +150,6 @@ class WillyWeatherDataUpdateCoordinator(DataUpdateCoordinator):
                 # Build forecast parameters based on enabled options
                 forecast_types = [
                     "weather",
-                    "precis",
                     "sunrisesunset",
                     "moonphases",
                     "rainfall",
@@ -193,7 +192,6 @@ class WillyWeatherDataUpdateCoordinator(DataUpdateCoordinator):
                     _LOGGER.info("No cached forecast data, fetching now")
                     forecast_types = [
                         "weather",
-                        "precis",
                         "sunrisesunset",
                         "moonphases",
                         "rainfall",


### PR DESCRIPTION
- Convert update interval inputs to sliders in config flow
- Fix invalid 'precis' forecast parameter causing API errors
- Add multi-select checkboxes for individual forecast sensors
- Add multi-select checkboxes for individual warning sensors
- Add new config flow steps for granular sensor selection
- Update binary_sensor.py to respect warning sensor selection