### PR TITLE
Fix forecast sensors config flow order and wind forecast API parameter

### DIFF
--- a/custom_components/willyweather/config_flow.py
+++ b/custom_components/willyweather/config_flow.py
@@ -146,10 +146,7 @@ class WillyWeatherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle forecast data options step."""
         if user_input is not None:
             self._forecast_options = user_input
-            # If forecast sensors enabled, go to forecast sensor selection
-            if user_input.get(CONF_INCLUDE_FORECAST_SENSORS, False):
-                return await self.async_step_forecast_sensors()
-            # Otherwise go to warnings
+            # Always go to warnings next
             return await self.async_step_warnings()
 
         data_schema = vol.Schema(
@@ -171,6 +168,10 @@ class WillyWeatherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle warning sensor options step."""
         if user_input is not None:
             self._warning_options = user_input
+            # If forecast sensors enabled, go to forecast sensor selection
+            if self._forecast_options.get(CONF_INCLUDE_FORECAST_SENSORS, False):
+                return await self.async_step_forecast_sensors()
+            # Otherwise go to update intervals
             return await self.async_step_update_intervals()
 
         data_schema = vol.Schema(
@@ -204,7 +205,7 @@ class WillyWeatherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle forecast sensor selection step."""
         if user_input is not None:
             self._forecast_sensor_options = user_input
-            return await self.async_step_warnings()
+            return await self.async_step_update_intervals()
 
         data_schema = vol.Schema(
             {
@@ -377,10 +378,7 @@ class WillyWeatherOptionsFlow(config_entries.OptionsFlow):
         """Manage forecast data options."""
         if user_input is not None:
             self._forecast_options = user_input
-            # If forecast sensors enabled, go to forecast sensor selection
-            if user_input.get(CONF_INCLUDE_FORECAST_SENSORS, False):
-                return await self.async_step_forecast_sensors()
-            # Otherwise go to warnings
+            # Always go to warnings next
             return await self.async_step_warnings()
 
         return self.async_show_form(
@@ -405,6 +403,10 @@ class WillyWeatherOptionsFlow(config_entries.OptionsFlow):
         """Manage warning sensor options."""
         if user_input is not None:
             self._warning_options = user_input
+            # If forecast sensors enabled, go to forecast sensor selection
+            if self._forecast_options.get(CONF_INCLUDE_FORECAST_SENSORS, False):
+                return await self.async_step_forecast_sensors()
+            # Otherwise go to update intervals
             return await self.async_step_update_intervals()
 
         return self.async_show_form(
@@ -438,7 +440,7 @@ class WillyWeatherOptionsFlow(config_entries.OptionsFlow):
         """Handle forecast sensor selection step."""
         if user_input is not None:
             self._forecast_sensor_options = user_input
-            return await self.async_step_warnings()
+            return await self.async_step_update_intervals()
 
         # Convert stored list of days to max days count for the dropdown
         stored_days = self.config_entry.options.get(CONF_FORECAST_DAYS, [0, 1, 2, 3, 4, 5, 6])

--- a/custom_components/willyweather/coordinator.py
+++ b/custom_components/willyweather/coordinator.py
@@ -154,16 +154,19 @@ class WillyWeatherDataUpdateCoordinator(DataUpdateCoordinator):
                     "moonphases",
                     "rainfall",
                     "temperature",
-                    "wind",
                 ]
 
+                include_wind = self.entry.options.get(CONF_INCLUDE_WIND, True)
                 include_tides = self.entry.options.get(CONF_INCLUDE_TIDES, False)
                 include_uv = self.entry.options.get(CONF_INCLUDE_UV, False)
                 include_swell = self.entry.options.get(CONF_INCLUDE_SWELL, False)
 
-                _LOGGER.debug("Options - Tides: %s, UV: %s, Swell: %s",
-                             include_tides, include_uv, include_swell)
+                _LOGGER.debug("Options - Wind: %s, Tides: %s, UV: %s, Swell: %s",
+                             include_wind, include_tides, include_uv, include_swell)
 
+                if include_wind:
+                    forecast_types.append("wind")
+                    _LOGGER.debug("Added wind to forecast types")
                 if include_tides:
                     forecast_types.append("tides")
                     _LOGGER.debug("Added tides to forecast types")
@@ -196,13 +199,15 @@ class WillyWeatherDataUpdateCoordinator(DataUpdateCoordinator):
                         "moonphases",
                         "rainfall",
                         "temperature",
-                        "wind",
                     ]
 
+                    include_wind = self.entry.options.get(CONF_INCLUDE_WIND, True)
                     include_tides = self.entry.options.get(CONF_INCLUDE_TIDES, False)
                     include_uv = self.entry.options.get(CONF_INCLUDE_UV, False)
                     include_swell = self.entry.options.get(CONF_INCLUDE_SWELL, False)
 
+                    if include_wind:
+                        forecast_types.append("wind")
                     if include_tides:
                         forecast_types.append("tides")
                     if include_uv:

--- a/custom_components/willyweather/sensor.py
+++ b/custom_components/willyweather/sensor.py
@@ -105,7 +105,7 @@ async def async_setup_entry(
             )
 
     # Add wind forecast sensors if enabled
-    if entry.options.get(CONF_INCLUDE_WIND, False):
+    if entry.options.get(CONF_INCLUDE_WIND, True):
         for sensor_type in WIND_FORECAST_TYPES:
             entities.append(
                 WillyWeatherWindForecastSensor(


### PR DESCRIPTION
- Reorder config flow: forecast_sensors now comes after warnings
- Make wind forecasts conditional based on CONF_INCLUDE_WIND setting
- Fix CONF_INCLUDE_WIND default inconsistency in sensor.py (was False, now True)
- This resolves the "invalid forecasts parameter" API error

The config flow order is now:
observational → forecast_options → warnings → forecast_sensors (if enabled) → update_intervals