### PR TITLE
Fix translation files step numbering and descriptions

### DIFF
--- a/custom_components/willyweather/strings.json
+++ b/custom_components/willyweather/strings.json
@@ -21,26 +21,26 @@
       },
       "forecast_options": {
         "title": "WillyWeather Setup - Forecast Data Options",
-        "description": "Step 3 of 6: Configure forecast data options for {station_name}\n\n**Forecast Data** (retrieved via weather.get_forecasts service call):\n- Wind forecast data adds wind speed/direction to forecast (requires wind enabled on your API key)\n\n**Forecast Sensors** create individual sensors for each day with temperature, rain, UV, etc.:\n- Enable the checkbox below to configure forecast sensors in the next step\n- No additional API calls required\n- Perfect for custom Lovelace cards\n- Easy automation triggers",
+        "description": "Step 3 of 6: Configure forecast data options for {station_name}\n\n**Forecast Data** (retrieved via weather.get_forecasts service call):\n- Wind forecast data adds wind speed/direction to forecast (requires wind enabled on your API key)\n\n**Forecast Sensors** create individual sensors for each day with temperature, rain, UV, etc.:\n- Enable the checkbox below to configure forecast sensors later\n- No additional API calls required\n- Perfect for custom Lovelace cards\n- Easy automation triggers",
         "data": {
           "include_wind": "Include wind forecast data (adds wind to weather.get_forecasts)",
-          "include_forecast_sensors": "Include daily forecast sensors (if enabled, you'll select which sensors in the next step)"
-        }
-      },
-      "forecast_sensors": {
-        "title": "WillyWeather Setup - Forecast Sensor Selection",
-        "description": "Step 4 of 6: Select which forecast sensors to create for {station_name}\n\n**Select Sensors:**\nChoose which data points to track for each forecast day.\n\n**Number of Days:**\nSelect how many days to forecast (1 = today only, 7 = today + next 6 days).",
-        "data": {
-          "forecast_monitored": "Forecast sensors to monitor",
-          "forecast_days": "Number of forecast days (1-7)"
+          "include_forecast_sensors": "Include daily forecast sensors (if enabled, you'll select which sensors in step 5)"
         }
       },
       "warnings": {
         "title": "WillyWeather Setup - Weather Warning Sensors",
-        "description": "Step 5 of 6: Configure weather warning sensors for {station_name}\n\n**Weather Warnings:**\nBinary sensors that alert you to dangerous weather conditions such as storms, floods, fires, and extreme temperatures.",
+        "description": "Step 4 of 6: Configure weather warning sensors for {station_name}\n\n**Weather Warnings:**\nBinary sensors that alert you to dangerous weather conditions such as storms, floods, fires, and extreme temperatures.",
         "data": {
           "include_warnings": "Include weather warning binary sensors",
           "warning_monitored": "Warning types to monitor"
+        }
+      },
+      "forecast_sensors": {
+        "title": "WillyWeather Setup - Forecast Sensor Selection",
+        "description": "Step 5 of 6: Select which forecast sensors to create for {station_name}\n\n**Select Sensors:**\nChoose which data points to track for each forecast day.\n\n**Number of Days:**\nSelect how many days to forecast (1 = today only, 7 = today + next 6 days).",
+        "data": {
+          "forecast_monitored": "Forecast sensors to monitor",
+          "forecast_days": "Number of forecast days (1-7)"
         }
       },
       "update_intervals": {

--- a/custom_components/willyweather/translations/en.json
+++ b/custom_components/willyweather/translations/en.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "WillyWeather Setup - Station Selection",
-        "description": "Step 1 of 4: Enter your WillyWeather API key.\n\n**Get your API key:**\nVisit https://www.willyweather.com.au/api/register.html to register and obtain your free API key.\n\n**Station ID:**\nLeaving the Station ID blank will automatically set it to the closest WillyWeather station to your Home Assistant Home Zone location. You can also manually enter a specific station ID if preferred.",
+        "description": "Step 1 of 6: Enter your WillyWeather API key.\n\n**Get your API key:**\nVisit https://www.willyweather.com.au/api/register.html to register and obtain your free API key.\n\n**Station ID:**\nLeaving the Station ID blank will automatically set it to the closest WillyWeather station to your Home Assistant Home Zone location. You can also manually enter a specific station ID if preferred.",
         "data": {
           "api_key": "WillyWeather API Key",
           "station_id": "Station ID (optional)"
@@ -11,7 +11,7 @@
       },
       "observational": {
         "title": "WillyWeather Setup - Observation Sensors",
-        "description": "Step 2 of 5: Configure optional observation sensors for {station_name}\n\n**Observation Sensors** provide current weather conditions (updated every 10-30 minutes):\n- Temperature, humidity, wind, pressure (always included when observational is enabled)\n- UV index\n- Tide information (coastal locations only)\n- Swell data (coastal locations only)",
+        "description": "Step 2 of 6: Configure optional observation sensors for {station_name}\n\n**Observation Sensors** provide current weather conditions (updated every 10-30 minutes):\n- Temperature, humidity, wind, pressure (always included when observational is enabled)\n- UV index (requires UV forecast enabled on your API key)\n- Tide information (requires tides enabled on your API key, coastal locations only)\n- Swell data (requires swell enabled on your API key, coastal locations only)\n\n**Note:** If optional features aren't enabled on your API key, they will be silently skipped.",
         "data": {
           "include_observational": "Include observational sensors (temperature, humidity, wind, pressure, etc.)",
           "include_uv": "Include UV index sensors",
@@ -21,26 +21,26 @@
       },
       "forecast_options": {
         "title": "WillyWeather Setup - Forecast Data Options",
-        "description": "Step 3 of 5: Configure forecast data options for {station_name}\n\n**Forecast Data** (retrieved via weather.get_forecasts service call):\n- Wind forecast data adds wind speed/direction to forecast\n\n**Forecast Sensors** create individual sensors for each day with temperature, rain, UV, etc.:\n- No additional API calls required\n- Perfect for custom Lovelace cards\n- Easy automation triggers",
+        "description": "Step 3 of 6: Configure forecast data options for {station_name}\n\n**Forecast Data** (retrieved via weather.get_forecasts service call):\n- Wind forecast data adds wind speed/direction to forecast (requires wind enabled on your API key)\n\n**Forecast Sensors** create individual sensors for each day with temperature, rain, UV, etc.:\n- Enable the checkbox below to configure forecast sensors later\n- No additional API calls required\n- Perfect for custom Lovelace cards\n- Easy automation triggers",
         "data": {
           "include_wind": "Include wind forecast data (adds wind to weather.get_forecasts)",
-          "include_forecast_sensors": "Include daily forecast sensors (creates individual sensors for each day)"
-        }
-      },
-      "forecast_sensors": {
-        "title": "WillyWeather Setup - Forecast Sensor Selection",
-        "description": "Step 4 of 5: Select which forecast sensors to create for {station_name}\n\n**Select Sensors:**\nChoose which data points to track for each forecast day.\n\n**Number of Days:**\nSelect how many days to forecast (1 = today only, 7 = today + next 6 days).",
-        "data": {
-          "forecast_monitored": "Forecast sensors to monitor",
-          "forecast_days": "Number of forecast days (1-7)"
+          "include_forecast_sensors": "Include daily forecast sensors (if enabled, you'll select which sensors in step 5)"
         }
       },
       "warnings": {
         "title": "WillyWeather Setup - Weather Warning Sensors",
-        "description": "Step 5 of 5: Configure weather warning sensors for {station_name}\n\n**Weather Warnings:**\nBinary sensors that alert you to dangerous weather conditions such as storms, floods, fires, and extreme temperatures.",
+        "description": "Step 4 of 6: Configure weather warning sensors for {station_name}\n\n**Weather Warnings:**\nBinary sensors that alert you to dangerous weather conditions such as storms, floods, fires, and extreme temperatures.",
         "data": {
           "include_warnings": "Include weather warning binary sensors",
           "warning_monitored": "Warning types to monitor"
+        }
+      },
+      "forecast_sensors": {
+        "title": "WillyWeather Setup - Forecast Sensor Selection",
+        "description": "Step 5 of 6: Select which forecast sensors to create for {station_name}\n\n**Select Sensors:**\nChoose which data points to track for each forecast day.\n\n**Number of Days:**\nSelect how many days to forecast (1 = today only, 7 = today + next 6 days).",
+        "data": {
+          "forecast_monitored": "Forecast sensors to monitor",
+          "forecast_days": "Number of forecast days (1-7)"
         }
       },
       "update_intervals": {


### PR DESCRIPTION
- Corrected step numbering to match actual config flow (1 of 6 through 6 of 6)
- Reordered warnings and forecast_sensors sections to match code flow (warnings is step 4, forecast_sensors is step 5)
- Updated observational step description to clarify API key requirements for optional features
- Updated forecast_options description to mention step 5 for forecast sensor selection
- Ensured both strings.json and en.json are in sync with consistent descriptions