### PR TITLE
Fix HTTP 400 error and config flow state handling issues

### DIFF
--- a/custom_components/willyweather/coordinator.py
+++ b/custom_components/willyweather/coordinator.py
@@ -304,15 +304,10 @@ class WillyWeatherDataUpdateCoordinator(DataUpdateCoordinator):
             "units": "distance:km,temperature:c,amount:mm,speed:km/h,pressure:hpa,tideHeight:m,swellHeight:m",
         }
 
-        headers = {
-            "Content-Type": "application/json",
-            "x-payload": '{"regionPrecis": true, "days": 7}',
-        }
-
         _LOGGER.info("Retrying forecast fetch with core types only: %s", forecast_types)
 
         async with async_timeout.timeout(API_TIMEOUT):
-            async with self._session.get(url, params=params, headers=headers) as response:
+            async with self._session.get(url, params=params) as response:
                 if response.status != 200:
                     response_text = await response.text()
                     _LOGGER.error("Core forecast types also failed: HTTP %s - %s", response.status, response_text[:500])
@@ -349,17 +344,11 @@ class WillyWeatherDataUpdateCoordinator(DataUpdateCoordinator):
             "units": "distance:km,temperature:c,amount:mm,speed:km/h,pressure:hpa,tideHeight:m,swellHeight:m",
         }
 
-        # Add x-payload header to request region-precis data
-        headers = {
-            "Content-Type": "application/json",
-            "x-payload": '{"regionPrecis": true, "days": 7}',
-        }
-
         _LOGGER.debug("Fetching forecast data with types: %s", forecast_types)
 
         try:
             async with async_timeout.timeout(API_TIMEOUT):
-                async with self._session.get(url, params=params, headers=headers) as response:
+                async with self._session.get(url, params=params) as response:
                     response_text = await response.text()
 
                     if response.status == 401:


### PR DESCRIPTION
This commit addresses two critical issues:

1. HTTP 400 Error: Removed inappropriate x-payload and Content-Type headers from forecast API GET requests. These headers were causing the WillyWeather API to reject requests with HTTP 400 errors. The API expects standard GET requests with only URL parameters.

2. Config Flow State Loss: Added defensive state handling and logging to prevent "unknown error" when users select forecast sensors during setup. Added:
   - getattr() with fallback values for description_placeholders
   - Debug logging at each config flow step to track state
   - Try-catch block for schema building in forecast_sensors step

These changes ensure the integration can be configured successfully and that forecast data fetches work correctly on all API keys.