### PR TITLE
Fix regionPrecis to use correct x-payload header format

### DIFF
--- a/custom_components/willyweather/coordinator.py
+++ b/custom_components/willyweather/coordinator.py
@@ -433,22 +433,22 @@ class WillyWeatherDataUpdateCoordinator(DataUpdateCoordinator):
         # Get today's date in YYYY-MM-DD format
         today = dt_util.now().strftime("%Y-%m-%d")
 
-        # RegionPrecis requires x-payload header with JSON body - use POST method
+        # RegionPrecis requires x-payload header with JSON object (not string)
+        import json
         headers = {
             "Content-Type": "application/json",
-        }
-
-        payload = {
-            "regionPrecis": True,
-            "days": days,
-            "startDate": today,
+            "x-payload": json.dumps({
+                "regionPrecis": True,
+                "days": days,
+                "startDate": today,
+            }),
         }
 
         _LOGGER.debug("Fetching regionPrecis data for %s days starting from %s", days, today)
 
         try:
             async with async_timeout.timeout(API_TIMEOUT):
-                async with self._session.post(url, headers=headers, json=payload) as response:
+                async with self._session.get(url, headers=headers) as response:
                     if response.status != 200:
                         response_text = await response.text()
                         _LOGGER.warning(


### PR DESCRIPTION
- Revert from POST back to GET method
- Use json.dumps() to properly serialize payload to JSON string
- x-payload header must contain JSON string, not dict
- WillyWeather API expects GET with x-payload header, not POST