### PR TITLE
Move extended forecast text to precis sensor attribute

### DIFF
--- a/custom_components/willyweather/const.py
+++ b/custom_components/willyweather/const.py
@@ -418,13 +418,6 @@ FORECAST_SENSOR_TYPES: Final = {
         "device_class": None,
         "state_class": None,
     },
-    "extended_text": {
-        "name": "Extended Forecast",
-        "unit": None,
-        "icon": "mdi:text-long",
-        "device_class": None,
-        "state_class": None,
-    },
     "rain_amount_min": {
         "name": "Rain Amount Min",
         "unit": UnitOfPrecipitationDepth.MILLIMETERS,

--- a/custom_components/willyweather/strings.json
+++ b/custom_components/willyweather/strings.json
@@ -37,7 +37,7 @@
       },
       "forecast_sensors": {
         "title": "WillyWeather Setup - Forecast Sensor Selection",
-        "description": "Step 5 of 6: Select which forecast sensors to create for {station_name}\n\n**Select Sensors:**\nChoose which data points to track for each forecast day.\n\n**Number of Days:**\nUse the slider to select forecast days (1 = today only, 7 = today + next 6 days).",
+        "description": "Step 5 of 6: Select which forecast sensors to create for {station_name}\n\n**Select Sensors:**\nChoose which data points to track for each forecast day.\n\n**Number of Days:**\nUse the slider to select forecast days (1 = today only, 7 = today + next 6 days).\n\n**Note:** Extended forecast text is available as the 'extended_forecast' attribute on the Short Forecast (precis) sensor to avoid character limits.",
         "data": {
           "forecast_monitored": "Forecast sensors to monitor",
           "forecast_days": "Number of forecast days"
@@ -89,7 +89,7 @@
       },
       "forecast_sensors": {
         "title": "WillyWeather Forecast Sensor Selection",
-        "description": "Select which forecast sensors to create.\n\n**Sensors:** Choose data points to track.\n**Days:** Use the slider to select forecast days (1 = today only, 7 = today + next 6 days).\n\nChanging these options will reload the integration.",
+        "description": "Select which forecast sensors to create.\n\n**Sensors:** Choose data points to track.\n**Days:** Use the slider to select forecast days (1 = today only, 7 = today + next 6 days).\n\n**Note:** Extended forecast text is available as the 'extended_forecast' attribute on the Short Forecast (precis) sensor to avoid character limits.\n\nChanging these options will reload the integration.",
         "data": {
           "forecast_monitored": "Forecast sensors to monitor",
           "forecast_days": "Number of forecast days"

--- a/custom_components/willyweather/translations/en.json
+++ b/custom_components/willyweather/translations/en.json
@@ -37,7 +37,7 @@
       },
       "forecast_sensors": {
         "title": "WillyWeather Setup - Forecast Sensor Selection",
-        "description": "Step 5 of 6: Select which forecast sensors to create for {station_name}\n\n**Select Sensors:**\nChoose which data points to track for each forecast day.\n\n**Number of Days:**\nSelect how many days to forecast (1 = today only, 7 = today + next 6 days).",
+        "description": "Step 5 of 6: Select which forecast sensors to create for {station_name}\n\n**Select Sensors:**\nChoose which data points to track for each forecast day.\n\n**Number of Days:**\nSelect how many days to forecast (1 = today only, 7 = today + next 6 days).\n\n**Note:** Extended forecast text is available as the 'extended_forecast' attribute on the Short Forecast (precis) sensor to avoid character limits.",
         "data": {
           "forecast_monitored": "Forecast sensors to monitor",
           "forecast_days": "Number of forecast days (1-7)"
@@ -89,7 +89,7 @@
       },
       "forecast_sensors": {
         "title": "WillyWeather Forecast Sensor Selection",
-        "description": "Select which forecast sensors to create.\n\n**Sensors:** Choose data points to track.\n**Days:** Number of forecast days (1 = today only, 7 = today + next 6 days).\n\nChanging these options will reload the integration.",
+        "description": "Select which forecast sensors to create.\n\n**Sensors:** Choose data points to track.\n**Days:** Number of forecast days (1 = today only, 7 = today + next 6 days).\n\n**Note:** Extended forecast text is available as the 'extended_forecast' attribute on the Short Forecast (precis) sensor to avoid character limits.\n\nChanging these options will reload the integration.",
         "data": {
           "forecast_monitored": "Forecast sensors to monitor",
           "forecast_days": "Number of forecast days (1-7)"


### PR DESCRIPTION
- Remove extended_text from FORECAST_SENSOR_TYPES (exceeds 255 char limit)
- Add extended_forecast attribute to precis sensor instead
- Update config flow descriptions to inform users about the change
- Extended text now accessible via attributes without character limits