### PR TITLE
Version 2.2.1 - Separate Extended Forecast sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,9 +228,10 @@ When observational sensors are enabled, the following sensors are created:
 
 #### Today's Forecast
 - **Today's Forecast** - Short forecast text for today (e.g., "Rainy")
-  - When **extended forecast text** is enabled, includes detailed forecast as an attribute:
-    - **extended_forecast** attribute - Detailed forecast text (e.g., "Cloudy. High chance of showers, most likely later this evening. Light winds becoming southerly 15 to 20 km/h in the evening then becoming light in the late evening.")
-    - **Note:** Requires 'Region Precis' enabled in WillyWeather API admin (extra API call, optional)
+- **Today's Extended Forecast** - Detailed narrative forecast for today (optional)
+  - State: Truncated to 255 characters (e.g., "Cloudy. High chance of showers, most likely later this evening. Light winds...")
+  - **full_text** attribute - Complete untruncated forecast text
+  - **Note:** Requires 'Region Precis' enabled in WillyWeather API admin (extra API call, optional)
 
 ### Sun & Moon Sensors
 Always included with observational sensors:

--- a/custom_components/willyweather/const.py
+++ b/custom_components/willyweather/const.py
@@ -222,7 +222,15 @@ SENSOR_TYPES: Final = {
         "icon": "mdi:weather-partly-cloudy",
         "device_class": None,
         "state_class": None,
-        "path": None,  # Special handling - uses weather forecast + regionPrecis data
+        "path": None,  # Special handling - uses weather forecast data
+    },
+    "forecast_extended": {
+        "name": "Today's Extended Forecast",
+        "unit": None,
+        "icon": "mdi:text-long",
+        "device_class": None,
+        "state_class": None,
+        "path": None,  # Special handling - uses regionPrecis data (truncated to 255 chars)
     },
 }
 

--- a/custom_components/willyweather/manifest.json
+++ b/custom_components/willyweather/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/safepay/willyweather-forecast-home-assistant/issues",
   "requirements": [],
-  "version": "2.2.0"
+  "version": "2.2.1"
 }

--- a/custom_components/willyweather/strings.json
+++ b/custom_components/willyweather/strings.json
@@ -11,7 +11,7 @@
       },
       "observational": {
         "title": "WillyWeather Setup - Observation Sensors",
-        "description": "Step 2 of 6: Configure optional observation sensors for {station_name}\n\n**Observation Sensors** provide current weather conditions (updated every 10-30 minutes):\n- Temperature, humidity, wind, pressure (always included when observational is enabled)\n- UV index (requires UV forecast enabled on your API key)\n- Tide information (requires tides enabled on your API key, coastal locations only)\n- Swell data (requires swell enabled on your API key, coastal locations only)\n\n**Extended Forecast Text:**\n- Detailed forecast text for today (e.g., \"Mostly sunny day. Slight chance of shower...\")\n- Appears as 'extended_forecast' attribute on the 'Today's Forecast' sensor\n- **IMPORTANT: Requires extra API call (adds cost) and must be enabled in WillyWeather API admin**\n\n**Note:** If optional features aren't enabled on your API key, they will be silently skipped.",
+        "description": "Step 2 of 6: Configure optional observation sensors for {station_name}\n\n**Observation Sensors** provide current weather conditions (updated every 10-30 minutes):\n- Temperature, humidity, wind, pressure (always included when observational is enabled)\n- UV index (requires UV forecast enabled on your API key)\n- Tide information (requires tides enabled on your API key, coastal locations only)\n- Swell data (requires swell enabled on your API key, coastal locations only)\n\n**Extended Forecast Text:**\n- Detailed forecast text for today (e.g., \"Mostly sunny day. Slight chance of shower...\")\n- Creates a 'Today's Extended Forecast' sensor (state truncated to 255 chars, full text in 'full_text' attribute)\n- **IMPORTANT: Requires extra API call (adds cost) and must be enabled in WillyWeather API admin**\n\n**Note:** If optional features aren't enabled on your API key, they will be silently skipped.",
         "data": {
           "include_observational": "Include observational sensors (temperature, humidity, wind, pressure, etc.)",
           "include_uv": "Include UV index sensors",
@@ -38,7 +38,7 @@
       },
       "forecast_sensors": {
         "title": "WillyWeather Setup - Forecast Sensor Selection",
-        "description": "Step 5 of 6: Select which forecast sensors to create for {station_name}\n\n**Select Sensors:**\nChoose which data points to track for each forecast day.\n\n**Number of Days:**\nUse the slider to select forecast days (1 = today only, 7 = today + next 6 days).\n\n**Note:** Extended forecast text is available as the 'extended_forecast' attribute on the 'Today's Forecast' observational sensor.",
+        "description": "Step 5 of 6: Select which forecast sensors to create for {station_name}\n\n**Select Sensors:**\nChoose which data points to track for each forecast day.\n\n**Number of Days:**\nUse the slider to select forecast days (1 = today only, 7 = today + next 6 days).\n\n**Note:** Extended forecast text is available in the 'Today's Extended Forecast' observational sensor (if enabled in Step 2).",
         "data": {
           "forecast_monitored": "Forecast sensors to monitor",
           "forecast_days": "Number of forecast days"
@@ -72,7 +72,7 @@
     "step": {
       "init": {
         "title": "WillyWeather Observation Sensors",
-        "description": "Configure observation sensors (current weather conditions).\n\n**Observation Sensors** provide current weather data updated every 10-30 minutes.\n\n**Extended Forecast Text:**\n- Detailed forecast text for today (appears as 'extended_forecast' attribute on 'Today's Forecast' sensor)\n- **IMPORTANT: Requires extra API call (adds cost) and must be enabled in WillyWeather API admin**\n\nChanging these options will reload the integration.",
+        "description": "Configure observation sensors (current weather conditions).\n\n**Observation Sensors** provide current weather data updated every 10-30 minutes.\n\n**Extended Forecast Text:**\n- Detailed forecast text for today (creates 'Today's Extended Forecast' sensor with state truncated to 255 chars, full text in 'full_text' attribute)\n- **IMPORTANT: Requires extra API call (adds cost) and must be enabled in WillyWeather API admin**\n\nChanging these options will reload the integration.",
         "data": {
           "include_observational": "Include observational sensors (temperature, humidity, wind, pressure, etc.)",
           "include_uv": "Include UV index sensors",
@@ -91,7 +91,7 @@
       },
       "forecast_sensors": {
         "title": "WillyWeather Forecast Sensor Selection",
-        "description": "Select which forecast sensors to create.\n\n**Sensors:** Choose data points to track.\n**Days:** Use the slider to select forecast days (1 = today only, 7 = today + next 6 days).\n\n**Note:** Extended forecast text is available as the 'extended_forecast' attribute on the 'Today's Forecast' observational sensor.\n\nChanging these options will reload the integration.",
+        "description": "Select which forecast sensors to create.\n\n**Sensors:** Choose data points to track.\n**Days:** Use the slider to select forecast days (1 = today only, 7 = today + next 6 days).\n\n**Note:** Extended forecast text is available in the 'Today's Extended Forecast' observational sensor (if enabled).\n\nChanging these options will reload the integration.",
         "data": {
           "forecast_monitored": "Forecast sensors to monitor",
           "forecast_days": "Number of forecast days"

--- a/custom_components/willyweather/translations/en.json
+++ b/custom_components/willyweather/translations/en.json
@@ -11,7 +11,7 @@
       },
       "observational": {
         "title": "WillyWeather Setup - Observation Sensors",
-        "description": "Step 2 of 6: Configure optional observation sensors for {station_name}\n\n**Observation Sensors** provide current weather conditions (updated every 10-30 minutes):\n- Temperature, humidity, wind, pressure (always included when observational is enabled)\n- UV index (requires UV forecast enabled on your API key)\n- Tide information (requires tides enabled on your API key, coastal locations only)\n- Swell data (requires swell enabled on your API key, coastal locations only)\n\n**Extended Forecast Text:**\n- Detailed forecast text for today (e.g., \"Mostly sunny day. Slight chance of shower...\")\n- Appears as 'extended_forecast' attribute on the 'Today's Forecast' sensor\n- **IMPORTANT: Requires extra API call (adds cost) and must be enabled in WillyWeather API admin**\n\n**Note:** If optional features aren't enabled on your API key, they will be silently skipped.",
+        "description": "Step 2 of 6: Configure optional observation sensors for {station_name}\n\n**Observation Sensors** provide current weather conditions (updated every 10-30 minutes):\n- Temperature, humidity, wind, pressure (always included when observational is enabled)\n- UV index (requires UV forecast enabled on your API key)\n- Tide information (requires tides enabled on your API key, coastal locations only)\n- Swell data (requires swell enabled on your API key, coastal locations only)\n\n**Extended Forecast Text:**\n- Detailed forecast text for today (e.g., \"Mostly sunny day. Slight chance of shower...\")\n- Creates a 'Today's Extended Forecast' sensor (state truncated to 255 chars, full text in 'full_text' attribute)\n- **IMPORTANT: Requires extra API call (adds cost) and must be enabled in WillyWeather API admin**\n\n**Note:** If optional features aren't enabled on your API key, they will be silently skipped.",
         "data": {
           "include_observational": "Include observational sensors (temperature, humidity, wind, pressure, etc.)",
           "include_uv": "Include UV index sensors",
@@ -38,7 +38,7 @@
       },
       "forecast_sensors": {
         "title": "WillyWeather Setup - Forecast Sensor Selection",
-        "description": "Step 5 of 6: Select which forecast sensors to create for {station_name}\n\n**Select Sensors:**\nChoose which data points to track for each forecast day.\n\n**Number of Days:**\nSelect how many days to forecast (1 = today only, 7 = today + next 6 days).\n\n**Note:** Extended forecast text is available as the 'extended_forecast' attribute on the 'Today's Forecast' observational sensor.",
+        "description": "Step 5 of 6: Select which forecast sensors to create for {station_name}\n\n**Select Sensors:**\nChoose which data points to track for each forecast day.\n\n**Number of Days:**\nSelect how many days to forecast (1 = today only, 7 = today + next 6 days).\n\n**Note:** Extended forecast text is available in the 'Today's Extended Forecast' observational sensor (if enabled in Step 2).",
         "data": {
           "forecast_monitored": "Forecast sensors to monitor",
           "forecast_days": "Number of forecast days (1-7)"
@@ -72,7 +72,7 @@
     "step": {
       "init": {
         "title": "WillyWeather Observation Sensors",
-        "description": "Configure observation sensors (current weather conditions).\n\n**Observation Sensors** provide current weather data updated every 10-30 minutes.\n\n**Extended Forecast Text:**\n- Detailed forecast text for today (appears as 'extended_forecast' attribute on 'Today's Forecast' sensor)\n- **IMPORTANT: Requires extra API call (adds cost) and must be enabled in WillyWeather API admin**\n\nChanging these options will reload the integration.",
+        "description": "Configure observation sensors (current weather conditions).\n\n**Observation Sensors** provide current weather data updated every 10-30 minutes.\n\n**Extended Forecast Text:**\n- Detailed forecast text for today (creates 'Today's Extended Forecast' sensor with state truncated to 255 chars, full text in 'full_text' attribute)\n- **IMPORTANT: Requires extra API call (adds cost) and must be enabled in WillyWeather API admin**\n\nChanging these options will reload the integration.",
         "data": {
           "include_observational": "Include observational sensors (temperature, humidity, wind, pressure, etc.)",
           "include_uv": "Include UV index sensors",
@@ -91,7 +91,7 @@
       },
       "forecast_sensors": {
         "title": "WillyWeather Forecast Sensor Selection",
-        "description": "Select which forecast sensors to create.\n\n**Sensors:** Choose data points to track.\n**Days:** Number of forecast days (1 = today only, 7 = today + next 6 days).\n\n**Note:** Extended forecast text is available as the 'extended_forecast' attribute on the 'Today's Forecast' observational sensor.\n\nChanging these options will reload the integration.",
+        "description": "Select which forecast sensors to create.\n\n**Sensors:** Choose data points to track.\n**Days:** Number of forecast days (1 = today only, 7 = today + next 6 days).\n\n**Note:** Extended forecast text is available in the 'Today's Extended Forecast' observational sensor (if enabled).\n\nChanging these options will reload the integration.",
         "data": {
           "forecast_monitored": "Forecast sensors to monitor",
           "forecast_days": "Number of forecast days (1-7)"


### PR DESCRIPTION
Changed extended forecast text from attribute to separate sensor:
- Add new 'Today's Extended Forecast' sensor (forecast_extended)
- State truncated to 255 characters (Home Assistant state limit)
- Full untruncated text available in 'full_text' attribute
- Removed extended_forecast attribute from Today's Forecast sensor
- Updated all documentation strings to reflect new approach
- More visible and accessible than attribute-only approach

Benefits:
✓ Extended text visible in UI (not hidden in attributes) ✓ State respects 255 character limit
✓ Full text still accessible via attribute
✓ Cleaner separation of concerns
✓ Better user experience

Version: 2.2.0 → 2.2.1