### PR TITLE
Fix entity ID assignment to properly apply prefix

### DIFF
--- a/custom_components/willyweather/binary_sensor.py
+++ b/custom_components/willyweather/binary_sensor.py
@@ -96,7 +96,7 @@ class WillyWeatherWarningBinarySensor(CoordinatorEntity, BinarySensorEntity):
         sensor_info = WARNING_BINARY_SENSOR_TYPES[sensor_type]
         self._attr_name = sensor_info["name"]
         self._attr_unique_id = f"{station_id}_{sensor_type}"
-        self._attr_entity_id = f"binary_sensor.{sensor_prefix}{sensor_type}"
+        self.entity_id = f"binary_sensor.{sensor_prefix}{sensor_type}"
         self._attr_icon = sensor_info["icon"]
         self._attr_device_class = sensor_info.get("device_class")
 

--- a/custom_components/willyweather/config_flow.py
+++ b/custom_components/willyweather/config_flow.py
@@ -392,10 +392,6 @@ class WillyWeatherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class WillyWeatherOptionsFlow(config_entries.OptionsFlow):
     """Handle options flow for WillyWeather."""
 
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        """Initialize options flow."""
-        self.config_entry = config_entry
-
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:

--- a/custom_components/willyweather/sensor.py
+++ b/custom_components/willyweather/sensor.py
@@ -196,7 +196,7 @@ class WillyWeatherSensor(CoordinatorEntity, SensorEntity):
         sensor_info = sensor_types_dict[sensor_type]
         self._attr_name = sensor_info["name"]
         self._attr_unique_id = f"{station_id}_{sensor_type}"
-        self._attr_entity_id = f"sensor.{sensor_prefix}{sensor_type}"
+        self.entity_id = f"sensor.{sensor_prefix}{sensor_type}"
         self._attr_native_unit_of_measurement = sensor_info["unit"]
         self._attr_icon = sensor_info["icon"]
         self._attr_device_class = sensor_info.get("device_class")
@@ -300,7 +300,7 @@ class WillyWeatherSunMoonSensor(CoordinatorEntity, SensorEntity):
         sensor_info = SUNMOON_SENSOR_TYPES[sensor_type]
         self._attr_name = sensor_info["name"]
         self._attr_unique_id = f"{station_id}_{sensor_type}"
-        self._attr_entity_id = f"sensor.{sensor_prefix}{sensor_type}"
+        self.entity_id = f"sensor.{sensor_prefix}{sensor_type}"
         self._attr_native_unit_of_measurement = sensor_info.get("unit")
         # Don't set icon here for moon_phase - we'll do it dynamically
         if sensor_type != "moon_phase":
@@ -460,7 +460,7 @@ class WillyWeatherTideSensor(CoordinatorEntity, SensorEntity):
         sensor_info = TIDES_SENSOR_TYPES[sensor_type]
         self._attr_name = sensor_info["name"]
         self._attr_unique_id = f"{station_id}_{sensor_type}"
-        self._attr_entity_id = f"sensor.{sensor_prefix}{sensor_type}"
+        self.entity_id = f"sensor.{sensor_prefix}{sensor_type}"
         self._attr_native_unit_of_measurement = sensor_info.get("unit")
         self._attr_icon = sensor_info["icon"]
         self._attr_device_class = sensor_info.get("device_class")
@@ -618,7 +618,7 @@ class WillyWeatherUVSensor(CoordinatorEntity, SensorEntity):
         sensor_info = UV_SENSOR_TYPES[sensor_type]
         self._attr_name = sensor_info["name"]
         self._attr_unique_id = f"{station_id}_{sensor_type}"
-        self._attr_entity_id = f"sensor.{sensor_prefix}{sensor_type}"
+        self.entity_id = f"sensor.{sensor_prefix}{sensor_type}"
         self._attr_native_unit_of_measurement = sensor_info.get("unit")
         self._attr_icon = sensor_info["icon"]
 
@@ -692,7 +692,7 @@ class WillyWeatherWindForecastSensor(CoordinatorEntity, SensorEntity):
         sensor_info = WIND_FORECAST_TYPES[sensor_type]
         self._attr_name = sensor_info["name"]
         self._attr_unique_id = f"{station_id}_{sensor_type}"
-        self._attr_entity_id = f"sensor.{sensor_prefix}{sensor_type}"
+        self.entity_id = f"sensor.{sensor_prefix}{sensor_type}"
         self._attr_native_unit_of_measurement = sensor_info.get("unit")
         self._attr_icon = sensor_info["icon"]
         self._attr_device_class = sensor_info.get("device_class")
@@ -755,7 +755,7 @@ class WillyWeatherSwellSensor(CoordinatorEntity, SensorEntity):
         sensor_info = SWELL_SENSOR_TYPES[sensor_type]
         self._attr_name = sensor_info["name"]
         self._attr_unique_id = f"{station_id}_{sensor_type}"
-        self._attr_entity_id = f"sensor.{sensor_prefix}{sensor_type}"
+        self.entity_id = f"sensor.{sensor_prefix}{sensor_type}"
         self._attr_native_unit_of_measurement = sensor_info.get("unit")
         self._attr_icon = sensor_info["icon"]
 
@@ -846,7 +846,7 @@ class WillyWeatherForecastSensor(CoordinatorEntity, SensorEntity):
         self._sensor_type = sensor_type
         self._forecast_day = forecast_day
         self._attr_unique_id = f"{station_id}_forecast_{sensor_type}_day_{forecast_day}"
-        self._attr_entity_id = f"sensor.{sensor_prefix}{sensor_type}_{forecast_day}"
+        self.entity_id = f"sensor.{sensor_prefix}{sensor_type}_{forecast_day}"
 
         sensor_config = FORECAST_SENSOR_TYPES[sensor_type]
         day_label = f"{forecast_day}"

--- a/custom_components/willyweather/weather.py
+++ b/custom_components/willyweather/weather.py
@@ -83,7 +83,10 @@ class WillyWeatherEntity(SingleCoordinatorWeatherEntity):
         self._station_id = entry.data[CONF_STATION_ID]
         self._station_name = entry.data.get(CONF_STATION_NAME, f"Station {self._station_id}")
         self._attr_unique_id = f"{self._station_id}_weather"
-        self._attr_entity_id = f"weather.{sensor_prefix}{self._station_id}"
+        # Sanitize station name for entity_id
+        sanitized_name = self._station_name.lower().replace(' ', '_').replace('-', '_')
+        sanitized_name = ''.join(c for c in sanitized_name if c.isalnum() or c == '_')
+        self.entity_id = f"weather.{sensor_prefix}{sanitized_name}"
         self._entry = entry
 
         self._attr_device_info = DeviceInfo(


### PR DESCRIPTION
- Change from _attr_entity_id to self.entity_id to properly set entity IDs
- Apply prefix to all sensor, binary_sensor, and weather entities
- Sanitize station name for weather entity_id
- Fix deprecation warning: remove explicit config_entry assignment in OptionsFlow

This ensures all entities are created with the user-configured prefix. Example: "ww_melbourne_" creates sensor.ww_melbourne_temperature