### PR TITLE
Fix config flow description - remove trailing underscore

### DIFF
--- a/custom_components/willyweather/strings.json
+++ b/custom_components/willyweather/strings.json
@@ -11,7 +11,7 @@
       },
       "prefix": {
         "title": "WillyWeather Setup - Entity Prefix",
-        "description": "Step 2 of 7: Configure the entity ID prefix for {station_name}\n\n**Default Entity Prefix:**\nThe default prefix includes your location name (e.g., \"ww_melbourne_\" creates entities like sensor.ww_melbourne_temperature).\n\n**Customization:**\nYou can edit the entire prefix to your preference, or leave it empty for no prefix.",
+        "description": "Step 2 of 7: Configure the entity ID prefix for {station_name}\n\n**Default Entity Prefix:**\nThe default prefix includes your location name (e.g., \"ww_melbourne\" creates entities like sensor.ww_melbourne_temperature).\n\n**Customization:**\nYou can edit the entire prefix to your preference, or leave it empty for no prefix.",
         "data": {
           "sensor_prefix": "Default entity prefix"
         }

--- a/custom_components/willyweather/translations/en.json
+++ b/custom_components/willyweather/translations/en.json
@@ -11,7 +11,7 @@
       },
       "prefix": {
         "title": "WillyWeather Setup - Entity Prefix",
-        "description": "Step 2 of 7: Configure the entity ID prefix for {station_name}\n\n**Default Entity Prefix:**\nThe default prefix includes your location name (e.g., \"ww_melbourne_\" creates entities like sensor.ww_melbourne_temperature).\n\n**Customization:**\nYou can edit the entire prefix to your preference, or leave it empty for no prefix.",
+        "description": "Step 2 of 7: Configure the entity ID prefix for {station_name}\n\n**Default Entity Prefix:**\nThe default prefix includes your location name (e.g., \"ww_melbourne\" creates entities like sensor.ww_melbourne_temperature).\n\n**Customization:**\nYou can edit the entire prefix to your preference, or leave it empty for no prefix.",
         "data": {
           "sensor_prefix": "Default entity prefix"
         }


### PR DESCRIPTION
Changed example from "ww_melbourne_" to "ww_melbourne" to match the actual prefix format used (no trailing underscore).

Updated both strings.json and translations/en.json.