### PR TITLE
Add OptionsFlow __init__ for HA 2025.11 compatibility

### DIFF
--- a/custom_components/willyweather/config_flow.py
+++ b/custom_components/willyweather/config_flow.py
@@ -392,6 +392,11 @@ class WillyWeatherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class WillyWeatherOptionsFlow(config_entries.OptionsFlow):
     """Handle options flow for WillyWeather."""
 
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        super().__init__()
+        self.config_entry = config_entry
+
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:


### PR DESCRIPTION
Added __init__ method to WillyWeatherOptionsFlow that:
- Calls super().__init__() to initialize parent class
- Stores config_entry for use in options flow steps

This fixes the TypeError when reconfiguring from the UI: "TypeError: WillyWeatherOptionsFlow() takes no arguments"

Compatible with HA 2025.11 and forward.