### PR TITLE
Add reconfigure step and migration support

### DIFF
--- a/custom_components/willyweather/__init__.py
+++ b/custom_components/willyweather/__init__.py
@@ -30,6 +30,51 @@ PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.WEATHER, Platform.BINARY_
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate old entry."""
+    _LOGGER.debug(
+        "Migrating configuration from version %s.%s",
+        config_entry.version,
+        config_entry.minor_version,
+    )
+
+    # Prevent downgrading from future versions
+    if config_entry.version > 1:
+        _LOGGER.error(
+            "Cannot downgrade from version %s.%s to version 1.1",
+            config_entry.version,
+            config_entry.minor_version,
+        )
+        return False
+
+    # Handle version 1 migrations
+    if config_entry.version == 1:
+        new_data = {**config_entry.data}
+        new_options = {**config_entry.options}
+
+        # Example: Add migrations here as needed
+        # if config_entry.minor_version < 2:
+        #     # Migration for version 1.2
+        #     pass
+
+        # Update to current version
+        hass.config_entries.async_update_entry(
+            config_entry,
+            data=new_data,
+            options=new_options,
+            minor_version=1,
+            version=1,
+        )
+
+    _LOGGER.debug(
+        "Migration to configuration version %s.%s successful",
+        config_entry.version,
+        config_entry.minor_version,
+    )
+
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up WillyWeather from a config entry."""
     coordinator = WillyWeatherDataUpdateCoordinator(hass, entry)

--- a/custom_components/willyweather/strings.json
+++ b/custom_components/willyweather/strings.json
@@ -62,6 +62,14 @@
           "night_start_hour": "Night start hour (0-23, e.g., 21 for 9 PM)",
           "night_end_hour": "Night end hour (0-23, e.g., 7 for 7 AM)"
         }
+      },
+      "reconfigure": {
+        "title": "Reconfigure WillyWeather",
+        "description": "Update your WillyWeather API credentials or station for {station_name}.\n\n**Note:** Changing the station ID will update your integration to use a different weather station. Leave the station ID blank to keep the current station.",
+        "data": {
+          "api_key": "WillyWeather API Key",
+          "station_id": "Station ID (leave blank to keep current)"
+        }
       }
     },
     "error": {

--- a/custom_components/willyweather/translations/en.json
+++ b/custom_components/willyweather/translations/en.json
@@ -62,6 +62,14 @@
           "night_start_hour": "Night start hour (0-23, e.g., 21 for 9 PM)",
           "night_end_hour": "Night end hour (0-23, e.g., 7 for 7 AM)"
         }
+      },
+      "reconfigure": {
+        "title": "Reconfigure WillyWeather",
+        "description": "Update your WillyWeather API credentials or station for {station_name}.\n\n**Note:** Changing the station ID will update your integration to use a different weather station. Leave the station ID blank to keep the current station.",
+        "data": {
+          "api_key": "WillyWeather API Key",
+          "station_id": "Station ID (leave blank to keep current)"
+        }
       }
     },
     "error": {


### PR DESCRIPTION
- Implement async_step_reconfigure for changing API credentials and station ID
  * Allows users to update API key without deleting and re-adding integration
  * Validates credentials before updating
  * Maintains unique ID consistency
  * Uses async_update_reload_and_abort per HA best practices

- Add async_migrate_entry function for future schema changes
  * Template for handling version migrations
  * Prevents downgrading from future versions
  * Supports both major and minor version changes

- Add translations for reconfigure step in strings.json and en.json

These improvements align with Home Assistant developer documentation requirements and advance the integration on the Integration Quality Scale.