### PR TITLE
fix: restore Home Assistant 2026.8 compatibility

### DIFF
--- a/custom_components/willyweather/__init__.py
+++ b/custom_components/willyweather/__init__.py
@@ -2,9 +2,8 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
 
-from homeassistant.const import CONF_API_KEY, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import async_get as async_get_device_registry
@@ -18,10 +17,10 @@ from .const import (
     DOMAIN,
     MANUFACTURER,
 )
-from .coordinator import WillyWeatherDataUpdateCoordinator
-
-if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
+from .coordinator import (
+    WillyWeatherConfigEntry,
+    WillyWeatherDataUpdateCoordinator,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,7 +29,9 @@ PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.WEATHER, Platform.BINARY_
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
-async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+async def async_migrate_entry(
+    hass: HomeAssistant, config_entry: WillyWeatherConfigEntry
+) -> bool:
     """Migrate old entry."""
     _LOGGER.debug(
         "Migrating configuration from version %s.%s",
@@ -75,13 +76,12 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: WillyWeatherConfigEntry) -> bool:
     """Set up WillyWeather from a config entry."""
     coordinator = WillyWeatherDataUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
 
     # Create main parent device
     station_id = entry.data.get(CONF_STATION_ID)
@@ -109,16 +109,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: WillyWeatherConfigEntry) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        coordinator = hass.data[DOMAIN].pop(entry.entry_id)
-        await coordinator.async_shutdown()
-
-    return unload_ok
+    # The coordinator registers its own shutdown against the entry, so unloading
+    # the platforms is all that is left to do here.
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
-async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def async_reload_entry(hass: HomeAssistant, entry: WillyWeatherConfigEntry) -> None:
     """Reload config entry when options change."""
     # Clean up entities that are no longer enabled
     await async_cleanup_disabled_entities(hass, entry)
@@ -126,7 +124,9 @@ async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     await hass.config_entries.async_reload(entry.entry_id)
 
 
-async def async_cleanup_disabled_entities(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def async_cleanup_disabled_entities(
+    hass: HomeAssistant, entry: WillyWeatherConfigEntry
+) -> None:
     """Remove entities for disabled sensor types."""
     entity_registry = async_get_entity_registry(hass)
     station_id = entry.data.get(CONF_STATION_ID)

--- a/custom_components/willyweather/binary_sensor.py
+++ b/custom_components/willyweather/binary_sensor.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 
 from datetime import timezone
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
@@ -25,21 +24,21 @@ from .const import (
     MANUFACTURER,
     WARNING_BINARY_SENSOR_TYPES,
 )
-from .coordinator import WillyWeatherDataUpdateCoordinator
-
-if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
+from .coordinator import (
+    WillyWeatherConfigEntry,
+    WillyWeatherDataUpdateCoordinator,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    entry: WillyWeatherConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up WillyWeather binary sensor based on a config entry."""
-    coordinator: WillyWeatherDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     entities = []
 

--- a/custom_components/willyweather/coordinator.py
+++ b/custom_components/willyweather/coordinator.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 import asyncio
 from datetime import timedelta
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import aiohttp
-import async_timeout
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
@@ -43,22 +44,24 @@ from .const import (
     UPDATE_INTERVAL_OBSERVATION,
 )
 
-if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
-
 _LOGGER = logging.getLogger(__name__)
 
+# The coordinator is stored on the entry itself rather than in hass.data, so the
+# alias is what gives every platform a typed handle on it via entry.runtime_data.
+type WillyWeatherConfigEntry = ConfigEntry["WillyWeatherDataUpdateCoordinator"]
 
-class WillyWeatherDataUpdateCoordinator(DataUpdateCoordinator):
+
+class WillyWeatherDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Class to manage fetching WillyWeather data from the API."""
 
-    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+    def __init__(self, hass: HomeAssistant, entry: WillyWeatherConfigEntry) -> None:
         """Initialize."""
-        self.hass = hass
         self.entry = entry
         self.api_key = entry.data[CONF_API_KEY]
         self.station_id = entry.data[CONF_STATION_ID]
-        self._session = aiohttp.ClientSession()
+        # The shared Home Assistant session is used rather than a private one so
+        # that connections are pooled with the rest of HA and torn down for us.
+        self._session = async_get_clientsession(hass)
         self._last_forecast_fetch: dt_util.dt.datetime | None = None
 
         _LOGGER.debug(
@@ -71,6 +74,9 @@ class WillyWeatherDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER,
             name=f"{DOMAIN}_{self.station_id}",
             update_interval=self._get_update_interval(),
+            # Required from Home Assistant 2026.8; without it the coordinator
+            # cannot tie its refresh task or reauth flow back to the entry.
+            config_entry=entry,
         )
 
     def _get_update_interval(self) -> timedelta:
@@ -284,7 +290,7 @@ class WillyWeatherDataUpdateCoordinator(DataUpdateCoordinator):
         _LOGGER.debug("Fetching observational data from: %s", url)
 
         try:
-            async with async_timeout.timeout(API_TIMEOUT):
+            async with asyncio.timeout(API_TIMEOUT):
                 async with self._session.get(url, params=params) as response:
                     response_text = await response.text()
                     
@@ -333,7 +339,7 @@ class WillyWeatherDataUpdateCoordinator(DataUpdateCoordinator):
 
         _LOGGER.info("Retrying forecast fetch with core types only: %s", forecast_types)
 
-        async with async_timeout.timeout(API_TIMEOUT):
+        async with asyncio.timeout(API_TIMEOUT):
             async with self._session.get(url, params=params) as response:
                 if response.status != 200:
                     response_text = await response.text()
@@ -374,7 +380,7 @@ class WillyWeatherDataUpdateCoordinator(DataUpdateCoordinator):
         _LOGGER.debug("Fetching forecast data with types: %s", forecast_types)
 
         try:
-            async with async_timeout.timeout(API_TIMEOUT):
+            async with asyncio.timeout(API_TIMEOUT):
                 async with self._session.get(url, params=params) as response:
                     response_text = await response.text()
 
@@ -452,7 +458,7 @@ class WillyWeatherDataUpdateCoordinator(DataUpdateCoordinator):
         _LOGGER.debug("Fetching regionPrecis data for %s days starting from %s", days, today)
 
         try:
-            async with async_timeout.timeout(API_TIMEOUT):
+            async with asyncio.timeout(API_TIMEOUT):
                 async with self._session.get(url, headers=headers) as response:
                     if response.status != 200:
                         response_text = await response.text()
@@ -495,7 +501,7 @@ class WillyWeatherDataUpdateCoordinator(DataUpdateCoordinator):
         _LOGGER.debug("Fetching warning data from: %s", url)
 
         try:
-            async with async_timeout.timeout(API_TIMEOUT):
+            async with asyncio.timeout(API_TIMEOUT):
                 async with self._session.get(url) as response:
                     if response.status == 401:
                         _LOGGER.error("API key is invalid (401 Unauthorized)")
@@ -530,10 +536,6 @@ class WillyWeatherDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER.debug("Network error fetching warning data: %s", err)
             return {"warnings": []}
 
-    async def async_shutdown(self) -> None:
-        """Close the aiohttp session."""
-        await self._session.close()
-
 
 async def async_get_station_id(
     hass: HomeAssistant, lat: float, lng: float, api_key: str
@@ -548,40 +550,41 @@ async def async_get_station_id(
 
     _LOGGER.debug("Searching for station at lat=%s, lng=%s", lat, lng)
 
+    session = async_get_clientsession(hass)
+
     try:
         # Use 30 second timeout for station search (one-time operation during setup)
-        async with async_timeout.timeout(30):
-            async with aiohttp.ClientSession() as session:
-                async with session.get(url, params=params) as response:
-                    if response.status == 401:
-                        _LOGGER.error("API key is invalid (401 Unauthorized)")
-                        return None
-                    elif response.status == 403:
-                        _LOGGER.error("API key does not have access (403 Forbidden)")
-                        return None
-                    elif response.status != 200:
-                        _LOGGER.error(
-                            "Error finding closest station: HTTP %s",
-                            response.status,
-                        )
-                        return None
+        async with asyncio.timeout(30):
+            async with session.get(url, params=params) as response:
+                if response.status == 401:
+                    _LOGGER.error("API key is invalid (401 Unauthorized)")
+                    return None
+                elif response.status == 403:
+                    _LOGGER.error("API key does not have access (403 Forbidden)")
+                    return None
+                elif response.status != 200:
+                    _LOGGER.error(
+                        "Error finding closest station: HTTP %s",
+                        response.status,
+                    )
+                    return None
 
-                    data = await response.json()
-                    location = data.get("location")
-                    if location:
-                        station_id = str(location.get("id"))
-                        station_name = location.get("name")
-                        distance = location.get("distance")
-                        _LOGGER.info(
-                            "Found closest station: %s (ID: %s) at %.1f km",
-                            station_name,
-                            station_id,
-                            distance if distance else 0,
-                        )
-                        return station_id
-                    else:
-                        _LOGGER.error("No location data in search response")
-                        return None
+                data = await response.json()
+                location = data.get("location")
+                if location:
+                    station_id = str(location.get("id"))
+                    station_name = location.get("name")
+                    distance = location.get("distance")
+                    _LOGGER.info(
+                        "Found closest station: %s (ID: %s) at %.1f km",
+                        station_name,
+                        station_id,
+                        distance if distance else 0,
+                    )
+                    return station_id
+                else:
+                    _LOGGER.error("No location data in search response")
+                    return None
 
     except asyncio.TimeoutError:
         _LOGGER.error("Timeout while searching for station (30s limit)")
@@ -606,38 +609,39 @@ async def async_get_station_name(
 
     _LOGGER.debug("Fetching station name for ID: %s", station_id)
 
+    session = async_get_clientsession(hass)
+
     try:
         # Use 30 second timeout for station name fetch (one-time operation during setup)
-        async with async_timeout.timeout(30):
-            async with aiohttp.ClientSession() as session:
-                async with session.get(url, params=params) as response:
-                    if response.status == 401:
-                        _LOGGER.error("API key is invalid (401 Unauthorized)")
-                        return None
-                    elif response.status == 403:
-                        _LOGGER.error("API key does not have access (403 Forbidden)")
-                        return None
-                    elif response.status == 404:
-                        _LOGGER.error("Station ID %s not found (404)", station_id)
-                        return None
-                    elif response.status != 200:
-                        _LOGGER.error(
-                            "Error fetching station info: HTTP %s",
-                            response.status,
-                        )
-                        return None
-                    
-                    data = await response.json()
-                    location = data.get("location", {})
-                    station_name = location.get("name")
-                    
-                    if station_name:
-                        _LOGGER.info("Station name: %s", station_name)
-                        return station_name
-                    else:
-                        _LOGGER.warning("No station name found in response")
-                        return f"Station {station_id}"
-                    
+        async with asyncio.timeout(30):
+            async with session.get(url, params=params) as response:
+                if response.status == 401:
+                    _LOGGER.error("API key is invalid (401 Unauthorized)")
+                    return None
+                elif response.status == 403:
+                    _LOGGER.error("API key does not have access (403 Forbidden)")
+                    return None
+                elif response.status == 404:
+                    _LOGGER.error("Station ID %s not found (404)", station_id)
+                    return None
+                elif response.status != 200:
+                    _LOGGER.error(
+                        "Error fetching station info: HTTP %s",
+                        response.status,
+                    )
+                    return None
+
+                data = await response.json()
+                location = data.get("location", {})
+                station_name = location.get("name")
+
+                if station_name:
+                    _LOGGER.info("Station name: %s", station_name)
+                    return station_name
+                else:
+                    _LOGGER.warning("No station name found in response")
+                    return f"Station {station_id}"
+
     except asyncio.TimeoutError:
         _LOGGER.error("Timeout while fetching station info")
         return None

--- a/custom_components/willyweather/sensor.py
+++ b/custom_components/willyweather/sensor.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 
 from datetime import datetime
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
@@ -37,21 +37,21 @@ from .const import (
     UV_SENSOR_TYPES,
     WIND_FORECAST_TYPES,
 )
-from .coordinator import WillyWeatherDataUpdateCoordinator
-
-if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
+from .coordinator import (
+    WillyWeatherConfigEntry,
+    WillyWeatherDataUpdateCoordinator,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    entry: WillyWeatherConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up WillyWeather sensor based on a config entry."""
-    coordinator: WillyWeatherDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     entities = []
 

--- a/custom_components/willyweather/weather.py
+++ b/custom_components/willyweather/weather.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from homeassistant.util import dt as dt_util
 
 from homeassistant.components.weather import (
@@ -20,7 +20,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import (
     ATTRIBUTION,
@@ -35,21 +35,21 @@ from .const import (
     DOMAIN,
     MANUFACTURER,
 )
-from .coordinator import WillyWeatherDataUpdateCoordinator
-
-if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
+from .coordinator import (
+    WillyWeatherConfigEntry,
+    WillyWeatherDataUpdateCoordinator,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    entry: WillyWeatherConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up WillyWeather weather entity based on a config entry."""
-    coordinator: WillyWeatherDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     # For backward compatibility: if CONF_SENSOR_PREFIX is not in options (existing installations),
     # use empty string. New installations will have it set to DEFAULT_SENSOR_PREFIX ("ww_").


### PR DESCRIPTION
Fixes compatibility with Home Assistant 2026.8, plus two related issues in the coordinator.

- **Pass `config_entry` to `DataUpdateCoordinator`.** Home Assistant marks the omission as breaking in 2026.8, so without this the integration stops setting up on the next release.
- **Replace `async_timeout` with `asyncio.timeout`.** `async_timeout` is no longer a Home Assistant dependency and its use is disallowed upstream; the import only resolved through a transitive dependency.
- **Use the shared Home Assistant aiohttp session** instead of creating one per config entry and one per setup call.

This also fixes a leak on reload: the old `async_shutdown` override closed the session but never called `super()`, leaving the coordinator's refresh timer running.

Alongside those, the coordinator moves from `hass.data` to `entry.runtime_data` with a typed config entry, and the platforms use `AddConfigEntryEntitiesCallback`.

Requires Home Assistant 2025.3.0 or newer. #84 raises the declared minimum in `hacs.json` to match, and should be merged with or before this.
