### PR TITLE
docs: correct repository metadata and refresh documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,133 @@
+# Contributing to the WillyWeather Integration
+
+Thanks for your interest in contributing to the WillyWeather integration for
+Home Assistant.
+
+## Development Setup
+
+1. Fork the repository
+2. Clone your fork: `git clone https://github.com/yourusername/willyweather-forecast-home-assistant.git`
+3. Create a branch: `git checkout -b fix/your-change`
+
+To test locally, copy (or symlink) `custom_components/willyweather` into your
+Home Assistant `config/custom_components/` directory and restart.
+
+Enable debug logging while working on the coordinator or config flow:
+
+```yaml
+logger:
+  default: warning
+  logs:
+    custom_components.willyweather: debug
+```
+
+## Directory Structure
+
+```
+willyweather-forecast-home-assistant/
+├── custom_components/
+│   └── willyweather/
+│       ├── __init__.py          # Integration setup, device registration, entity cleanup
+│       ├── manifest.json        # Integration metadata (version lives here)
+│       ├── config_flow.py       # Config and options flow
+│       ├── coordinator.py       # DataUpdateCoordinator and API calls
+│       ├── const.py             # Constants and sensor type definitions
+│       ├── weather.py           # Weather entity platform
+│       ├── sensor.py            # Sensor platform
+│       ├── binary_sensor.py     # Warning binary sensor platform
+│       ├── strings.json         # UI strings
+│       └── translations/
+│           └── en.json          # English translations
+├── .github/
+│   ├── RELEASING.md             # How releases are cut
+│   └── workflows/               # Hassfest, HACS validation, release
+├── README.md
+├── CHANGELOG.md
+├── hacs.json                    # HACS metadata
+└── info.md                      # Shown inside HACS
+```
+
+## Minimum Home Assistant Version
+
+The integration targets **Home Assistant 2025.3.0 and newer**, declared in
+[hacs.json](hacs.json). If a change requires a newer Home Assistant API, raise
+that value in the same pull request and say so in the description — otherwise
+users on older versions get an integration that fails to load rather than a
+clear "requires a newer Home Assistant" message from HACS.
+
+## Code Style
+
+- Follow PEP 8
+- Use type hints on function signatures
+- Add docstrings to modules, classes and methods
+- Prefer the Home Assistant helpers over rolling your own:
+  - `async_get_clientsession(hass)` for HTTP — never construct a `ClientSession`
+  - `asyncio.timeout` for timeouts (`async_timeout` is banned in Home Assistant)
+  - `entry.runtime_data` for per-entry state, not `hass.data`
+
+## Changing Sensors
+
+Entity `unique_id`s are what tie an entity to its history. Changing one orphans
+the old entity and starts the recorder history over, which users notice.
+
+If a change renames or removes an entity:
+
+- Say so explicitly in the pull request
+- Add an entry to [CHANGELOG.md](CHANGELOG.md) describing what users must do
+- Expect it to be released as a **major** version bump
+
+## API Usage
+
+The WillyWeather API is billed per call, so changes to polling behaviour carry a
+real cost for users. If a change alters how often the integration calls the API,
+or adds a new endpoint:
+
+- State the before/after call volume in the pull request
+- Put new endpoints behind a config option, defaulting to off, when they are not
+  needed by every user
+
+## Testing
+
+There is no automated test suite yet, so please verify by hand and say what you
+checked:
+
+1. The integration loads without errors on a fresh install
+2. The config flow completes, including auto-detection of the station
+3. The options flow saves and reloads correctly
+4. The entities you touched appear with the expected state and attributes
+5. Reloading the entry (**Configure** → save) does not leave duplicate or
+   orphaned entities
+6. Nothing new appears in the log at WARNING or above
+
+Coastal features (tides, swell) need a coastal station to test — if you cannot,
+say so rather than assuming.
+
+## Pull Requests
+
+1. Update the README if you add or change a feature
+2. **Do not bump the version** in `manifest.json` — the release workflow does
+   that. See [.github/RELEASING.md](.github/RELEASING.md)
+3. Give the PR a descriptive title; release notes are generated from PR titles,
+   so the title becomes the changelog entry
+4. Link any related issues
+
+Hassfest and HACS validation run automatically on every pull request. Both need
+to be green before merge.
+
+## Reporting Issues
+
+Please include:
+
+- Home Assistant version
+- Integration version (shown on the device page)
+- Relevant log output with `custom_components.willyweather` set to debug
+- Your station ID or location, and whether it is coastal
+- Steps to reproduce, plus expected vs actual behaviour
+
+Redact your API key from any logs before posting.
+
+## Questions
+
+Open an issue with your question or discussion topic.
+
+Thank you for contributing!

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # WillyWeather Integration for Home Assistant
-[![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/custom-components/hacs) [![willyweather](https://img.shields.io/github/release/safepay/sensor.willyweather.svg)](https://github.com/safepay/sensor.willyweather) ![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)
+[![HACS](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
+[![GitHub Release](https://img.shields.io/github/v/release/safepay/willyweather-forecast-home-assistant)](https://github.com/safepay/willyweather-forecast-home-assistant/releases)
+[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.3.0+-blue.svg)](https://www.home-assistant.io/)
+[![License](https://img.shields.io/github/license/safepay/willyweather-forecast-home-assistant)](LICENSE)
+![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)
 
 A custom Home Assistant integration providing comprehensive weather data from WillyWeather Australia.
 
@@ -21,15 +25,28 @@ This differs from the BoM integration by providing separate binary sensors for w
 - **Forecast Data**: Daily (7 days) and hourly (3 days) with comprehensive data points
 - **Separate Update Intervals**: Configure different update frequencies for observational vs forecast data to reduce API usage
 
+## Requirements
+
+- Home Assistant **2025.3.0** or newer
+- A WillyWeather API key (see [Getting an API Key](#getting-an-api-key) below)
+
 ## Installation
 
-### HACS (Recommended, but not yet available!)
-1. Add this repository as a custom repository in HACS
-2. Search for "WillyWeather" in HACS
-3. Click **Install**
+### HACS (Recommended)
+
+This integration is not in the HACS default store yet, so it has to be added as a
+custom repository first. That is a one-off step — updates arrive through HACS as
+normal afterwards.
+
+1. In HACS, open the **⋮** menu (top right) → **Custom repositories**
+2. Add `https://github.com/safepay/willyweather-forecast-home-assistant` with type **Integration**
+3. Search for "WillyWeather" in HACS and click **Download**
 4. Restart Home Assistant
 
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=safepay&repository=willyweather-forecast-home-assistant&category=integration)
+
 ### Manual Installation
+
 1. Copy the `custom_components/willyweather` folder to your Home Assistant's `custom_components` directory
 2. Restart Home Assistant
 
@@ -55,11 +72,11 @@ You need a WillyWeather API key to use this integration:
 6. Add "Region Precis" for the optional long forecast text sensor for today.
 
 ### Full API Configuration Example
-![WillyWeather API Config](https://github.com/safepay/sensor.willyweather/blob/master/willyweather_api_config.png?raw=true)
+![WillyWeather API Config](https://raw.githubusercontent.com/safepay/willyweather-forecast-home-assistant/master/willyweather_api_config.png)
 
 ### Minimal API Configuration Example
 (For areas without tide and swell information)
-![WillyWeather API Config](https://github.com/safepay/sensor.willyweather/blob/master/willyweather_api_config_minimal.png?raw=true)
+![WillyWeather API Config](https://raw.githubusercontent.com/safepay/willyweather-forecast-home-assistant/master/willyweather_api_config_minimal.png)
 
 ### Available Configuration Options
 
@@ -349,7 +366,7 @@ If automatic station detection fails:
 4. Manually enter this ID during setup
 
 ### API Rate Limits
-The free WillyWeather API has rate limits. The integration updates every 10 minutes by default.
+The WillyWeather API is billed per call and your plan has a call limit. By default the integration fetches observational data every 10 minutes and forecast data every 30 minutes during the day, which works out at roughly 7,900 calls a month with warnings enabled — see [Update Interval Configuration](#update-interval-configuration) to tune this.
 
 ### Warnings Not Showing
 Warning sensors only appear when warnings are active in your area. During periods without active warnings, the sensors will show as "off" with no attributes.
@@ -357,8 +374,16 @@ Warning sensors only appear when warnings are active in your area. During period
 ## Support
 
 For issues, feature requests, or questions:
-- [GitHub Issues](https://github.com/safepay/sensor.willyweather/issues)
+
+- [GitHub Issues](https://github.com/safepay/willyweather-forecast-home-assistant/issues)
 - [Home Assistant Community Forum](https://community.home-assistant.io/)
+
+## Contributing
+
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for
+development setup, what to check before opening a pull request, and the rules
+around changing entities. Releases are cut by maintainers using the process in
+[.github/RELEASING.md](.github/RELEASING.md).
 
 ## Credits
 

--- a/custom_components/willyweather/manifest.json
+++ b/custom_components/willyweather/manifest.json
@@ -5,13 +5,9 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/safepay/willyweather-forecast-home-assistant",
+  "integration_type": "service",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/safepay/willyweather-forecast-home-assistant/issues",
   "requirements": [],
   "version": "2.4.1"
 }
-
-
-
-
-

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,7 @@
 {
     "name": "WillyWeather Forecast and Sensor Integration",
+    "render_readme": true,
     "content_in_root": false,
-    "homeassistant": "2025.1.0",
+    "homeassistant": "2025.3.0",
     "country": ["AU"]
 }

--- a/info.md
+++ b/info.md
@@ -1,4 +1,9 @@
-[![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/custom-components/hacs) [![willyweather](https://img.shields.io/github/release/safepay/sensor.willyweather.svg)](https://github.com/safepay/sensor.willyweather) ![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)
+# WillyWeather Integration
+
+[![HACS](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
+[![GitHub Release](https://img.shields.io/github/v/release/safepay/willyweather-forecast-home-assistant)](https://github.com/safepay/willyweather-forecast-home-assistant/releases)
+[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.3.0+-blue.svg)](https://www.home-assistant.io/)
+![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)
 
 A custom Home Assistant integration providing comprehensive weather data from WillyWeather Australia.
 
@@ -14,16 +19,26 @@ This differs from the BoM integration by providing separate binary sensors for w
 - **Weather Warnings**: Binary sensors for active storm, flood, fire, heat, wind, frost warnings and more
 - **Automatic Station Detection**: Automatically finds the closest WillyWeather station based on your Home Assistant location
 - **Configurable Data**: Enable/disable optional sensors through the UI
-- **Configurable Update Intervals**: Set different update frequencies for day and night to manage API usage
+- **Forecast Sensors**: Optional per-day sensors (0-6), preconfigured for the Platinum Weather Card
+- **Configurable Update Intervals**: Separate day/night frequencies for observational and forecast data to manage API usage
 - **Forecast Data**: Daily (7 days) and hourly (3 days) with comprehensive data points
 
 ## API Usage Management
 
-The integration includes configurable day/night update intervals to help manage API usage:
-- Default: 10-minute updates during the day, 30-minute updates at night
-- Fully customizable through the UI (5-60 minutes day, 10-120 minutes night)
+The WillyWeather API is paid (roughly $1.20/month for a typical configuration), so
+observational and forecast data are polled on **separate** schedules — current
+conditions stay fresh while forecasts, which change far less often, are fetched
+less frequently and cached in between.
+
+- Observational defaults: 10 minutes during the day, 30 minutes at night
+- Forecast defaults: 30 minutes during the day, 60 minutes at night
 - Automatically switches between day and night modes
-- Each update makes 2-3 API calls depending on configuration
-- Typical usage with defaults: ~10,000 calls/month
+- 1-2 API calls per observational update, 2-3 when a forecast refresh is due
+- Typical usage with defaults: ~7,900 calls/month
 
 Configure update intervals during setup or anytime through **Settings** → **Devices & Services** → **WillyWeather** → **Configure**.
+
+## Requirements
+
+- Home Assistant 2025.3.0 or newer
+- A [WillyWeather API key](https://www.willyweather.com.au/info/api.html)


### PR DESCRIPTION
- **Corrects the minimum Home Assistant version** in `hacs.json` from 2025.1.0 to 2025.3.0. `AddConfigEntryEntitiesCallback`, used from #82, was only added in 2025.3.0 — at the old value HACS would install a version that fails to load rather than reporting Home Assistant as too old.
- **Adds `render_readme`** to `hacs.json` so HACS shows the README, and `"integration_type": "service"` to `manifest.json`.
- **Fixes stale links.** The badges and both API configuration screenshots pointed at `safepay/sensor.willyweather`, the repository's former name, and resolved only through GitHub's rename redirect. Screenshots now use raw URLs so they also render inside HACS.
- **Rewrites the HACS installation section**, which was headed "Recommended, but not yet available!" while giving working custom-repository instructions. It now explains that the integration is not in the HACS default store and gives the full steps.
- **Updates the API usage figures** in `info.md`, which still described a single update interval and ~10,000 calls a month rather than the current split observational/forecast intervals (~7,900). The README's troubleshooting section also described the API as free, which contradicts the introduction.
- **Adds CONTRIBUTING.md**, covering local setup, entity `unique_id` stability, API call volume, and that the release workflow owns version bumps.

One link points at `.github/RELEASING.md`, which arrives in #83.
