### PR TITLE
fix: give each device a model so the list reads consistently

### DIFF
--- a/custom_components/willyweather/__init__.py
+++ b/custom_components/willyweather/__init__.py
@@ -16,6 +16,7 @@ from .const import (
     DEFAULT_SENSOR_PREFIX,
     DOMAIN,
     MANUFACTURER,
+    MODEL_STATION,
     VERSION,
 )
 from .coordinator import (
@@ -99,6 +100,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: WillyWeatherConfigEntry)
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, station_id)},
         manufacturer=MANUFACTURER,
+        model=MODEL_STATION,
         name=device_name,
         sw_version=VERSION,
     )

--- a/custom_components/willyweather/binary_sensor.py
+++ b/custom_components/willyweather/binary_sensor.py
@@ -22,6 +22,7 @@ from .const import (
     DEFAULT_SENSOR_PREFIX,
     DOMAIN,
     MANUFACTURER,
+    MODEL_BINARY_SENSORS,
     WARNING_BINARY_SENSOR_TYPES,
 )
 from .coordinator import (
@@ -111,6 +112,7 @@ class WillyWeatherWarningBinarySensor(CoordinatorEntity, BinarySensorEntity):
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, f"{station_id}_binary_sensors")},
             manufacturer=MANUFACTURER,
+            model=MODEL_BINARY_SENSORS,
             name=f"{station_name} Binary Sensors",
             via_device=(DOMAIN, station_id),
         )

--- a/custom_components/willyweather/const.py
+++ b/custom_components/willyweather/const.py
@@ -25,6 +25,15 @@ MANUFACTURER: Final = "WillyWeather"
 # HACS installed. Keep the `VERSION = "X.Y.Z"` form -- the workflow greps for it.
 VERSION: Final = "2.4.2"
 
+# Device models. The device list picks its subtitle as
+# `model || sw_version || manufacturer`, so without a model the station device
+# would show the bare version number while its children showed the manufacturer.
+# Naming each device's role is more use than either.
+MODEL_STATION: Final = "Weather Station"
+MODEL_SENSORS: Final = "Observations"
+MODEL_BINARY_SENSORS: Final = "Warnings"
+MODEL_FORECAST_SENSORS: Final = "Forecast"
+
 # Configuration
 CONF_STATION_ID: Final = "station_id"
 CONF_STATION_NAME: Final = "station_name"

--- a/custom_components/willyweather/sensor.py
+++ b/custom_components/willyweather/sensor.py
@@ -30,6 +30,8 @@ from .const import (
     DOMAIN,
     FORECAST_SENSOR_TYPES,
     MANUFACTURER,
+    MODEL_FORECAST_SENSORS,
+    MODEL_SENSORS,
     SENSOR_TYPES,
     SUNMOON_SENSOR_TYPES,
     SWELL_SENSOR_TYPES,
@@ -222,6 +224,7 @@ class WillyWeatherSensor(CoordinatorEntity, SensorEntity):
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, f"{station_id}_sensors")},
             manufacturer=MANUFACTURER,
+            model=MODEL_SENSORS,
             name=f"{station_name} Sensors",
             via_device=(DOMAIN, station_id),
         )
@@ -326,6 +329,7 @@ class WillyWeatherSunMoonSensor(CoordinatorEntity, SensorEntity):
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, f"{station_id}_sensors")},
             manufacturer=MANUFACTURER,
+            model=MODEL_SENSORS,
             name=f"{station_name} Sensors",
             via_device=(DOMAIN, station_id),
             )
@@ -483,6 +487,7 @@ class WillyWeatherTideSensor(CoordinatorEntity, SensorEntity):
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, f"{station_id}_sensors")},
             manufacturer=MANUFACTURER,
+            model=MODEL_SENSORS,
             name=f"{station_name} Sensors",
             via_device=(DOMAIN, station_id),
             )
@@ -641,6 +646,7 @@ class WillyWeatherUVSensor(CoordinatorEntity, SensorEntity):
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, f"{station_id}_sensors")},
             manufacturer=MANUFACTURER,
+            model=MODEL_SENSORS,
             name=f"{station_name} Sensors",
             via_device=(DOMAIN, station_id),
             )
@@ -751,6 +757,7 @@ class WillyWeatherWindForecastSensor(CoordinatorEntity, SensorEntity):
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, f"{station_id}_sensors")},
             manufacturer=MANUFACTURER,
+            model=MODEL_SENSORS,
             name=f"{station_name} Sensors",
             via_device=(DOMAIN, station_id),
             )
@@ -846,6 +853,7 @@ class WillyWeatherSwellSensor(CoordinatorEntity, SensorEntity):
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, f"{station_id}_sensors")},
             manufacturer=MANUFACTURER,
+            model=MODEL_SENSORS,
             name=f"{station_name} Sensors",
             via_device=(DOMAIN, station_id),
             )
@@ -983,6 +991,7 @@ class WillyWeatherForecastSensor(CoordinatorEntity, SensorEntity):
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, f"{station_id}_forecast_sensors")},
             manufacturer=MANUFACTURER,
+            model=MODEL_FORECAST_SENSORS,
             name=f"{station_name} Forecast Sensors",
             via_device=(DOMAIN, station_id),
         )

--- a/custom_components/willyweather/weather.py
+++ b/custom_components/willyweather/weather.py
@@ -34,6 +34,8 @@ from .const import (
     DEFAULT_SENSOR_PREFIX,
     DOMAIN,
     MANUFACTURER,
+    MODEL_STATION,
+    VERSION,
 )
 from .coordinator import (
     WillyWeatherConfigEntry,
@@ -97,7 +99,9 @@ class WillyWeatherEntity(SingleCoordinatorWeatherEntity):
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, self._station_id)},
             manufacturer=MANUFACTURER,
+            model=MODEL_STATION,
             name=self._station_name,
+            sw_version=VERSION,
         )
 
     @property


### PR DESCRIPTION
The device list picks its subtitle as `model || sw_version || manufacturer`. Adding `sw_version` to the station device in 139ae5f meant that device began showing a bare `2.4.2`, while its three child devices still showed `WillyWeather` — none of them set a `model`, so they fell through to the manufacturer.

Gives each device a model naming its role, which is more useful than repeating the manufacturer four times and makes the rows consistent:

| device | subtitle before | subtitle after |
|---|---|---|
| Muckleford South | `2.4.2` | `Weather Station` |
| Muckleford South Sensors | `WillyWeather` | `Observations` |
| Muckleford South Binary Sensors | `WillyWeather` | `Warnings` |
| Muckleford South Forecast Sensors | `WillyWeather` | `Forecast` |

The version is not lost — the device page renders `sw_version` on its own line, labelled *Version* for service-type devices.

Also sets `sw_version` on the weather entity's `DeviceInfo`, which describes the same device as the registration in `__init__.py`, so the two agree rather than relying on merge order.

No entity or device identifiers change, so nothing is orphaned and no migration is needed.
