### PR TITLE
docs: fix broken README links and state the correct licence

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![HACS](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
 [![GitHub Release](https://img.shields.io/github/v/release/safepay/willyweather-forecast-home-assistant)](https://github.com/safepay/willyweather-forecast-home-assistant/releases)
 [![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.3.0+-blue.svg)](https://www.home-assistant.io/)
-[![License](https://img.shields.io/github/license/safepay/willyweather-forecast-home-assistant)](LICENSE)
+[![License](https://img.shields.io/github/license/safepay/willyweather-forecast-home-assistant)](https://github.com/safepay/willyweather-forecast-home-assistant/blob/master/LICENSE)
 ![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)
 
 A custom Home Assistant integration providing comprehensive weather data from WillyWeather Australia.
@@ -380,10 +380,10 @@ For issues, feature requests, or questions:
 
 ## Contributing
 
-Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for
+Contributions are welcome — see [CONTRIBUTING.md](https://github.com/safepay/willyweather-forecast-home-assistant/blob/master/CONTRIBUTING.md) for
 development setup, what to check before opening a pull request, and the rules
 around changing entities. Releases are cut by maintainers using the process in
-[.github/RELEASING.md](.github/RELEASING.md).
+[.github/RELEASING.md](https://github.com/safepay/willyweather-forecast-home-assistant/blob/master/.github/RELEASING.md).
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -391,4 +391,6 @@ This integration uses the [WillyWeather API](https://www.willyweather.com.au/inf
 
 ## License
 
-This project is licensed under the MIT License.
+This project is licensed under the GNU General Public License v3.0. See
+[LICENSE](https://github.com/safepay/willyweather-forecast-home-assistant/blob/master/LICENSE)
+for the full text.


### PR DESCRIPTION
Two fixes to the README, one of which turned up while diagnosing the other.

**Relative links were dead in HACS.** `LICENSE`, `CONTRIBUTING.md` and `.github/RELEASING.md` were linked by relative path. Those resolve on GitHub but not in HACS, which renders the README in its own frontend with no repository context to resolve against — so they broke as soon as `render_readme` was enabled in b6cf808. All three are now absolute and verified to return 200.

The badge images were never at fault; every one of them returns 200. Only the link targets were broken.

**The README claimed the wrong licence.** `LICENSE` has held the full GPL-3.0 text since the initial commit bf87a73, and GitHub detects the repository as GPL-3.0 — but the README said "licensed under the MIT License", added later in 509b08f. The licence badge made the contradiction visible by correctly rendering `license: GPL-3.0` directly above it.

The `LICENSE` file is what governs and is unchanged. Only the README text is corrected, so nothing is relicensed.
