### PR TITLE
docs: correct stale references in the README, translations and issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,8 +40,8 @@ body:
     id: version
     attributes:
       label: Integration version
-      description: Which version of the integration are you using?
-      placeholder: e.g., 1.5.0
+      description: Which version of the integration are you using? Shown on the device page.
+      placeholder: e.g., 2.4.2
     validations:
       required: true
 
@@ -49,8 +49,17 @@ body:
     id: ha-version
     attributes:
       label: Home Assistant version
-      description: Which version of Home Assistant are you running?
-      placeholder: e.g., 2024.1.0
+      description: Which version of Home Assistant are you running? The integration requires 2025.3.0 or newer.
+      placeholder: e.g., 2025.3.0
+    validations:
+      required: true
+
+  - type: input
+    id: station
+    attributes:
+      label: Station
+      description: Your station ID or location, and whether it is coastal. Tide and swell sensors need a coastal station.
+      placeholder: Station ID or suburb, and coastal or not
     validations:
       required: true
 
@@ -58,7 +67,7 @@ body:
     id: logs
     attributes:
       label: Relevant log output
-      description: Please copy and paste any relevant log output
+      description: Log output with `custom_components.willyweather` set to debug. Redact your API key before posting.
       render: shell
 
   - type: textarea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to the WillyWeather Home Assistant integration will be docum
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.2] - 2026-08-01
+
+### Fixed
+- **Home Assistant 2026.8 compatibility**: The integration would have stopped loading on Home Assistant 2026.8
+  - The update coordinator is now tied to the config entry, which also stops a refresh timer being left running on every reload
+  - Requires Home Assistant 2025.3.0 or newer
+- **Device list subtitles**: Each device now names its role — Weather Station, Observations, Warnings, Forecast — instead of showing a bare version number or repeating the manufacturer
+
+### Changed
+- Uses Home Assistant's shared HTTP session rather than opening one per config entry
+- Documentation links now resolve when the README is viewed inside HACS
+- Licence stated correctly as GPL-3.0
+
+### Added
+- Releases are bumped, tagged and published by a workflow (see `.github/RELEASING.md`)
+
+## [2.4.1] - 2026-01-30
+
+### Fixed
+- **Setup form link**: The API registration link on the first setup step rendered as a raw `{api_register_url}` placeholder instead of the URL
+
 ## [2.4.0] - 2025-12-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -56,8 +56,12 @@ normal afterwards.
 3. Search for "WillyWeather"
 4. Follow the setup wizard:
    - **Step 1**: Enter your WillyWeather API key (optional: specify a station ID, or leave blank for auto-detection)
-   - **Step 2**: Select which sensors to include
-   - **Step 3**: Select to include binary warning sensors
+   - **Step 2**: Set the entity prefix (defaults to `ww_` plus the station name, e.g. `ww_melbourne`)
+   - **Step 3**: Select which observational sensors to include
+   - **Step 4**: Choose forecast data options
+   - **Step 5**: Select to include binary warning sensors
+   - **Step 6**: Select which per-day forecast sensors to create
+   - **Step 7**: Set the update intervals
 
 ## Configuration
 
@@ -82,6 +86,7 @@ You need a WillyWeather API key to use this integration:
 
 When setting up, you can configure:
 
+- **Entity prefix** - Applied to every entity ID and friendly name (default: `ww_` plus the station name, e.g. `ww_melbourne`)
 - **Include observational sensors** - Enables current weather measurement sensors (default: Yes)
 - **Include wind forecast data** - Includes wind speed and direction forecasts (default: Yes)
 - **Include UV index sensors** - Includes UV index and alert levels (default: Yes)
@@ -122,11 +127,11 @@ The default sensor selection is optimized for the popular [Platinum Weather Card
 - Each sensor updates automatically with the forecast data
 - Configurable: Choose 1-7 days of forecast (default: 5 days)
 
-**Example sensors created:**
-- `sensor.willyweather_icon_0`
-- `sensor.willyweather_short_forecast_1`
-- `sensor.willyweather_max_temperature_2`
-- `sensor.willyweather_rain_probability_3`
+**Example sensors created** (station "Melbourne", default prefix):
+- `sensor.ww_melbourne_icon_0`
+- `sensor.ww_melbourne_short_forecast_1`
+- `sensor.ww_melbourne_max_temperature_2`
+- `sensor.ww_melbourne_rain_probability_3`
 
 All forecast sensors are grouped under a separate "Forecast Sensors" device for easy organization.
 
@@ -216,7 +221,7 @@ service: weather.get_forecasts
 data:
   type: daily
 target:
-  entity_id: weather.willyweather_
+  entity_id: weather.ww_melbourne
 ```
 
 ### Observational Sensors (Current Conditions)
@@ -244,8 +249,8 @@ When observational sensors are enabled, the following sensors are created:
 - **Rain Today** - Total rainfall today in mm
 - **Rain Since 9am** - Rainfall since 9am in mm
 
-#### Today's Forecast
-- **Today's Forecast** - Short forecast text for today (e.g., "Rainy")
+#### Forecast Text
+- **Precis** - Short forecast text for today (e.g., "Rainy")
 - **Today's Extended Forecast** - Detailed narrative forecast for today (optional)
   - State: Truncated to 255 characters (e.g., "Cloudy. High chance of showers, most likely later this evening. Light winds...")
   - **full_text** attribute - Complete untruncated forecast text
@@ -300,14 +305,10 @@ Available warning types:
 - **Flood Warning**
 - **Fire Warning**
 - **Heat Warning**
-- **Wind Warning**
-- **Weather Warning**
 - **Strong Wind Warning**
-- **Thunderstorm Warning**
 - **Frost Warning**
 - **Rain Warning**
 - **Snow Warning**
-- **Hail Warning**
 - **Cyclone Warning**
 - **Tsunami Warning**
 - **Fog Warning**
@@ -331,17 +332,17 @@ automation:
   - alias: "Severe Weather Alert"
     trigger:
       - platform: state
-        entity_id: binary_sensor.storm_warning
+        entity_id: binary_sensor.ww_melbourne_storm_warning
         to: "on"
     condition:
       - condition: template
-        value_template: "{{ state_attr('binary_sensor.storm_warning', 'severity') == 'red' }}"
+        value_template: "{{ state_attr('binary_sensor.ww_melbourne_storm_warning', 'severity') == 'red' }}"
     action:
       - service: notify.mobile_app
         data:
           message: >
             SEVERE STORM WARNING! 
-            {{ state_attr('binary_sensor.storm_warning', 'warning_count') }} warning(s) active.
+            {{ state_attr('binary_sensor.ww_melbourne_storm_warning', 'warning_count') }} warning(s) active.
           title: "⚠️ Weather Alert"
 ```
 

--- a/custom_components/willyweather/translations/en.json
+++ b/custom_components/willyweather/translations/en.json
@@ -45,10 +45,10 @@
       },
       "forecast_sensors": {
         "title": "WillyWeather Setup - Forecast Sensor Selection",
-        "description": "Step 6 of 7: Select which forecast sensors to create for {station_name}\n\n**Select Sensors:**\nChoose which data points to track for each forecast day.\n\n**Number of Days:**\nSelect how many days to forecast (1 = today only, 7 = today + next 6 days).\n\n**Note:** Extended forecast text is available in the 'Today's Extended Forecast' observational sensor (if enabled in Step 3).",
+        "description": "Step 6 of 7: Select which forecast sensors to create for {station_name}\n\n**Select Sensors:**\nChoose which data points to track for each forecast day.\n\n**Number of Days:**\nUse the slider to select forecast days (1 = today only, 7 = today + next 6 days).\n\n**Note:** Extended forecast text is available in the 'Today's Extended Forecast' observational sensor (if enabled in Step 3).",
         "data": {
           "forecast_monitored": "Forecast sensors to monitor",
-          "forecast_days": "Number of forecast days (1-7)"
+          "forecast_days": "Number of forecast days"
         }
       },
       "update_intervals": {
@@ -106,10 +106,10 @@
       },
       "forecast_sensors": {
         "title": "WillyWeather Forecast Sensor Selection",
-        "description": "Select which forecast sensors to create.\n\n**Sensors:** Choose data points to track.\n**Days:** Number of forecast days (1 = today only, 7 = today + next 6 days).\n\n**Note:** Extended forecast text is available in the 'Today's Extended Forecast' observational sensor (if enabled).\n\nChanging these options will reload the integration.",
+        "description": "Select which forecast sensors to create.\n\n**Sensors:** Choose data points to track.\n**Days:** Use the slider to select forecast days (1 = today only, 7 = today + next 6 days).\n\n**Note:** Extended forecast text is available in the 'Today's Extended Forecast' observational sensor (if enabled).\n\nChanging these options will reload the integration.",
         "data": {
           "forecast_monitored": "Forecast sensors to monitor",
-          "forecast_days": "Number of forecast days (1-7)"
+          "forecast_days": "Number of forecast days"
         }
       },
       "warnings": {


### PR DESCRIPTION
Documentation and UI strings had drifted from the code. No functional change.

- **README entity IDs.** Entities carry the prefix set at setup, which
  defaults to `ww_` plus the station name, so every example ID in the README
  was wrong — the warning automation could not have worked as pasted. The
  prefix itself was undocumented, and the setup wizard was described as three
  steps when it has seven.
- **README sensor and warning names.** The precis sensor was still under its
  pre-2.4.0 name. The warning list offered fifteen types; eleven exist.
- **Translations.** `translations/en.json` had drifted from `strings.json` in
  four values. Home Assistant serves `en.json`, so the stale wording was what
  users saw. The files now match.
- **Changelog.** 2.4.1 and 2.4.2 were undocumented, including the Home
  Assistant 2026.8 compatibility fix.
- **Bug report template.** Placeholders suggested a Home Assistant version
  below the 2025.3.0 floor. Adds the station field CONTRIBUTING.md asks for.

Workflow branch references were checked and are correct as they stand,
including `hacs/action@main` alongside `hassfest@master` — those match each
action's own default branch.
